### PR TITLE
[PKG-4416] 0.1.54 ❄️ 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python
     - pydantic >=1.0.0,<3.0.0
     - requests >=2.0.0,<3.0.0
+    - orjson >=3.9.14,<4.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "langsmith" %}
-{% set version = "0.0.87" %}
+{% set version = "0.1.54" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 36c4cc47e5b54be57d038036a30fb19ce6e4c73048cd7a464b8f25b459694d34
-
+  url: https://github.com/langchain-ai/langsmith-sdk/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b84646c6972719927bb44ce0d8f1f0753b90cefa3a3a99b112be7ac1ec7683c3
+  
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install ./python --no-deps --no-build-isolation -vv
   entry_points:
     - langsmith = langsmith.cli.main:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - pytest-asyncio
     - pytest-rerunfailures
     - attrs
-    - dataclasses-json  # [py<312]
+    - dataclasses-json
   commands:
     - pip check
     # Requires dependent package langchain
@@ -50,8 +50,7 @@ test:
     # Test labeled as flaky by upstream, but consistently fails on aarch64.
     {% set tests_to_skip = tests_to_skip + " or test_client_gc" %}  # [aarch64]
     # Requires dataclasses-json
-    - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})" --ignore="python/tests/unit_tests/test_client.py"  # [py>=312]
-    - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})"  # [py<312]
+    - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://smith.langchain.com/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,8 @@ test:
     {% set tests_to_skip = "test_as_runnable" %}
     # Requires building from git repository
     {% set tests_to_skip = tests_to_skip + " or test_git_info" %}
+    # Test labeled as flaky by upstream, but consistently fails on aarch64.
+    {% set tests_to_skip = tests_to_skip + " or test_client_gc" %}  # [aarch64]
     # Requires dataclasses-json
     - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})" --ignore="python/tests/unit_tests/test_client.py"  # [py>=312]
     - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})"  # [py<312]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,15 +27,29 @@ requirements:
     - orjson >=3.9.14,<4.0.0
 
 test:
+  source_files:
+    - python/tests
+    - python/pyproject.toml
   imports:
     - langsmith
     - langsmith.schemas
     - langsmith.client
   requires:
     - pip
+    - pytest
+    - pytest-asyncio
+    - pytest-rerunfailures
+    - attrs
+    - dataclasses-json  # [py<312]
   commands:
     - pip check
-    - langsmith -h
+    # Requires dependent package langchain
+    {% set tests_to_skip = "test_as_runnable" %}
+    # Requires building from git repository
+    {% set tests_to_skip = tests_to_skip + " or test_git_info" %}
+    # Requires dataclasses-json
+    - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})" --ignore="python/tests/unit_tests/test_client.py"  # [py>=312]
+    - pytest python/tests/unit_tests -k "not ({{ tests_to_skip }})"  # [py<312]
 
 about:
   home: https://smith.langchain.com/


### PR DESCRIPTION
langsmith 0.1.54 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4416]
- [Upstream repository](https://github.com/langchain-ai/langsmith-sdk/tree/v0.1.54/python)
- [Upstream changelog/diff](https://github.com/langchain-ai/langsmith-sdk/releases/tag/v0.1.54)

### Explanation of changes:

- Added upstream unit tests. 
  - Excluded test directories:
    - `integration_tests`: Requires Langsmith API key.
    - `evaluation`: Requires Langsmith API key.
    - `external`: Requires OpenAI API key.
  - Skipped tests:
    - `test_as_runnable`: Requires langchain, which is dependent on this package.
    - `test_git_info`: Only works within the langsmith-sdk git repository.
    - `test_client_gc` (aarch64 only): Marked as flaky by upstream. Set to rerun on failure, but consistently fails on aarch64.


[PKG-4416]: https://anaconda.atlassian.net/browse/PKG-4416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ