### PR TITLE
langsmith 0.6.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,8 @@ requirements:
 {% set ignore_tests = ignore_tests + " --ignore=tests/external/test_instructor_evals.py" %}
 # E requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.smith.langchain.com/datasets?limit=1&name=None.tests.evaluation.test_evaluation
 {% set ignore_tests = ignore_tests + " --ignore=tests/evaluation/test_evaluation.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_uuid_v7.py" %}  # [win]
+
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
 {% set ignore_tests = ignore_tests + " --ignore=tests/evaluation/test_evaluation.py" %}
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_uuid_v7.py" %}  # [win]
 # dataclasses-json is not available in main channel for Python 3.14.
-{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_utils.py" %}  # [py<314]
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_utils.py" %}  # [py==314]
 
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a90bb8297fe0d3c63d9868ea58fe46c52d7e2d1f06b614e43c6a78c948275f24
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   skip: True  # [py<39]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langsmith" %}
-{% set version = "0.4.32" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a90bb8297fe0d3c63d9868ea58fe46c52d7e2d1f06b614e43c6a78c948275f24
+  sha256: b60f1785aed4dac5e01f24db01aa18fa1af258bad4531e045e739438daa3f8c2
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
-  skip: True  # [py<39]
+  number: 0
+  skip: True  # [py<310]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
   host:
@@ -21,20 +21,23 @@ requirements:
     - pip
   run:
     - python
-    - pydantic >=1,<3
-    - requests >=2.0.0
-    - orjson >=3.9.14  # [python_impl !='pypy']
     - httpx >=0.23.0,<1
-    - requests-toolbelt >=1.0.0
-    - zstandard >=0.23.0
+    - orjson >=3.9.14
     - packaging >=23.2
+    - pydantic >=2,<3
+    - requests >=2.0.0
+    - requests-toolbelt >=1.0.0
+    - uuid-utils >=0.12.0,<1.0
+    - zstandard >=0.23.0
   run_constrained:
-    - langsmith-pyo3 >=0.1.0rc2
-    - opentelemetry-sdk >=1.30.0
-    - opentelemetry-api>=1.30.0
-    - opentelemetry-exporter-otlp-proto-http >=1.30.0
-    - openai-agents >=0.0.3
-    - vcrpy >=7.0.0
+    - langsmith-pyo3 >=0.1.0rc2,<0.2.0
+    - rich >=13.9.4
+    - pytest >=7.0.0
+    - openai-agents >=0.0.3,<0.1
+    - opentelemetry-sdk >=1.30.0,<2.0.0
+    - opentelemetry-api >=1.30.0,<2.0.0
+    - opentelemetry-exporter-otlp-proto-http >=1.30.0,<2.0.0
+    - claude-agent-sdk>=0.1.0  # [py>=310]
 
 # ERROR tests/integration_tests - ModuleNotFoundError: No module named 'vcr'
 # vcrpy 7.0.0 is not available in main channel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,8 @@ requirements:
 # E requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.smith.langchain.com/datasets?limit=1&name=None.tests.evaluation.test_evaluation
 {% set ignore_tests = ignore_tests + " --ignore=tests/evaluation/test_evaluation.py" %}
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_uuid_v7.py" %}  # [win]
+# dataclasses-json is not available in main channel for Python 3.14.
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_utils.py" %}  # [py<314]
 
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,8 @@ test:
     - opentelemetry-exporter-otlp-proto-http >=1.30.0
     - anthropic >=0.45.0
     - pytest-tornasync
-    - dataclasses-json
+    # dataclasses-json is not maintained anymore and not available in main channel for Python 3.14.
+    - dataclasses-json  # [py<314]
     - multipart
     - attrs
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
 {% set ignore_tests = ignore_tests + " --ignore=tests/external/test_instructor_evals.py" %}
 # E requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.smith.langchain.com/datasets?limit=1&name=None.tests.evaluation.test_evaluation
 {% set ignore_tests = ignore_tests + " --ignore=tests/evaluation/test_evaluation.py" %}
-{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_uuid_v7.py" %}  # [win]
+{% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_uuid_v7.py" %}
 # dataclasses-json is not available in main channel for Python 3.14.
 {% set ignore_tests = ignore_tests + " --ignore=tests/unit_tests/test_utils.py" %}  # [py==314]
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11705) 
- [Upstream repository](https://github.com/langchain-ai/langsmith-sdk/tree/v0.6.0)

### Explanation of changes:

- Update dependencies
- Skip the test that requires the unmaintained package `dataclasses-json`.
- Skip a flaky test.

### Notes:

-