### PR TITLE
PKG-13957 Bump langsmith to 0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langsmith" %}
-{% set version = "0.6.0" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b60f1785aed4dac5e01f24db01aa18fa1af258bad4531e045e739438daa3f8c2
+  sha256: 59fe5b2a56bbbe14a08aa76691f84b49e8675dd21e11b57d80c6db8c08bac2e3
 
 build:
   number: 0
@@ -29,6 +29,7 @@ requirements:
     - requests-toolbelt >=1.0.0
     - uuid-utils >=0.12.0,<1.0
     - zstandard >=0.23.0
+    - xxhash >=3.0.0
   run_constrained:
     - langsmith-pyo3 >=0.1.0rc2,<0.2.0
     - rich >=13.9.4


### PR DESCRIPTION
## Summary
- Bump version and sdist sha256 to **0.8.0**
- Add **xxhash >=3.0.0** to run requirements (upstream)

## Testing
- [ ] CI (conda-build matrix)

Made with [Cursor](https://cursor.com)